### PR TITLE
Fix bug when url has empty search

### DIFF
--- a/source/modules/dynamic_images.js
+++ b/source/modules/dynamic_images.js
@@ -37,7 +37,7 @@ const self = {
 
     // Append params to query string
     Object.keys(params).forEach((key) => {
-      if(parsed.search.length) parsed.search += '&';
+      if(parsed.search && parsed.search.length) parsed.search += '&';
       parsed.search += encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);
     });
     parsed.search = parsed.search.replace(/^&/, '');


### PR DESCRIPTION
### Hi Cory!

There is a small issue in this module. `search` property in parsed URL can be `null`, so I just added validation to prevent exception.

---

_All code contributions are subject to the terms of the Contributor License Agreement described in CONTRIBUTING.md._
