### PR TITLE
Added 'APP_HOST' config parameter in '.env.example' for 'app.listen' …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 NODE_ENV=production
 APP_URL=https://example.com/
 APP_PORT=3000
+APP_HOST=127.0.0.1
 
 # Slugs
 APP_ADMIN_SLUG=admin

--- a/app.js
+++ b/app.js
@@ -112,7 +112,7 @@ Promise.resolve()
     app.use(ErrorController.applicationError);
 
     // Start sailing! ⚓️
-    app.listen(process.env.APP_PORT, () => {
+    app.listen(process.env.APP_PORT, process.env.APP_HOST, () => {
       console.info('Postleaf publishing on port %d! 🌱', process.env.APP_PORT);
     });
   })

--- a/app.js
+++ b/app.js
@@ -112,7 +112,7 @@ Promise.resolve()
     app.use(ErrorController.applicationError);
 
     // Start sailing! ⚓️
-    app.listen(process.env.APP_PORT, process.env.APP_HOST || '0.0.0.0', () => {
+    app.listen(process.env.APP_PORT, process.env.APP_HOST || '::', () => {
       console.info('Postleaf publishing on port %d! 🌱', process.env.APP_PORT);
     });
   })

--- a/app.js
+++ b/app.js
@@ -112,7 +112,7 @@ Promise.resolve()
     app.use(ErrorController.applicationError);
 
     // Start sailing! ⚓️
-    app.listen(process.env.APP_PORT, process.env.APP_HOST, () => {
+    app.listen(process.env.APP_PORT, process.env.APP_HOST || '0.0.0.0', () => {
       console.info('Postleaf publishing on port %d! 🌱', process.env.APP_PORT);
     });
   })


### PR DESCRIPTION
…method in '/app.js' to let the node process listen to a certain interface instead of all interfaces.

### Pull Request Summary

To listen to all interfaces, set 'APP_HOST' to '0.0.0.0'.

---

_All code contributions are subject to the terms of the Contributor License Agreement described in CONTRIBUTING.md._
