### PR TITLE
Fix URL parameters in dynamic images

### DIFF
--- a/source/modules/dynamic_images.js
+++ b/source/modules/dynamic_images.js
@@ -36,10 +36,15 @@ const self = {
     }
 
     // Append params to query string
-    Object.keys(params).forEach((key) => {
-      if(parsed.search && parsed.search.length) parsed.search += '&';
-      parsed.search += encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);
-    });
+    let keys = Object.keys(params);
+    if(keys.length > 0) {
+      if(parsed.search == null)
+        parsed.search = '';
+      keys.forEach((key) => {
+        if(parsed.search.length > 0) parsed.search += '&';
+        parsed.search += encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);
+      });
+    }
     parsed.search = parsed.search.replace(/^&/, '');
     url = Url.format(parsed);
 

--- a/source/modules/dynamic_images.js
+++ b/source/modules/dynamic_images.js
@@ -38,8 +38,7 @@ const self = {
     // Append params to query string
     let keys = Object.keys(params);
     if(keys.length > 0) {
-      if(parsed.search == null)
-        parsed.search = '';
+      if(parsed.search == null) parsed.search = '';
       keys.forEach((key) => {
         if(parsed.search.length > 0) parsed.search += '&';
         parsed.search += encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);


### PR DESCRIPTION
### Pull Request Summary

URL generation in dynamic images is a bit buggy, it prepends a `null` word before search part of URL so the first parameter never works, for example:
```
/uploads/2018/02/cover.png?nullwidth=2000
```

---

_All code contributions are subject to the terms of the Contributor License Agreement described in CONTRIBUTING.md._