### PR TITLE
Relative link in the admin layout file

### DIFF
--- a/source/views/admin/layout.dust
+++ b/source/views/admin/layout.dust
@@ -17,7 +17,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="{@url path="assets/images/favicon.png"/}">
   <link rel="apple-touch-icon" href="{@url path="assets/images/app_icon.png"/}">
-  <link rel="stylesheet" href="{@url path="assets/css/lib.css" absolute="true"/}">
+  <link rel="stylesheet" href="{@url path="assets/css/lib.css"/}">
   {! Styles !}
   {#styles}
     <link rel="stylesheet" href="{@url path=./}">


### PR DESCRIPTION
Addresses [#81](https://github.com/Postleaf/postleaf/issues/81) to some extent 

This fix allows the admin UI to look as expected. The css files resolve correctly. 

If a port number like 3000 is specified on a production install and not included in `APP_URL` other functionality will still break as pointed out in the comments.    

A solution to that can be to construct the URL from the parameters supplied in the config file.  

In the [absolute](https://github.com/Postleaf/postleaf/blob/master/source/modules/make_url.js#L38) function the port number may be appended if the existing url does not already contain a port number? 

In the mean time this PR can atleast render the admin panel correctly.

### Pull Request Summary

Please describe what your PR does here. Be detailed so the changes you're proposing are obvious.

---

_All code contributions are subject to the terms of the Contributor License Agreement described in CONTRIBUTING.md._
