### PR TITLE
table identifier added to getPosts Helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,7 @@ SMTP_PORT=587
 SMTP_SECURE=false
 SMTP_FROM_NAME=Your Name
 SMTP_FROM_EMAIL=you@example.com
+
+# Dynamic image processing
+# Maximum width for dynamically resized images. If not set, original image size will be used as max width.
+# IMG_MAX_WIDTH=800

--- a/source/modules/dynamic_images.js
+++ b/source/modules/dynamic_images.js
@@ -83,8 +83,9 @@ const self = {
               // Do nothing if no image exists or if it's less than 200px wide
               if(!upload || upload.width < 200) return;
 
-              // Create dynamic images at 200px intervals up to the original width
-              for(let width = 200; width < upload.width; width += 200) {
+              // Create dynamic images at 200px intervals up to the original width or the max width set in .env
+              let maxWidth = process.env.IMG_MAX_WIDTH ? process.env.IMG_MAX_WIDTH : upload.width;
+              for(let width = 200; width < maxWidth; width += 200) {
                 let url = SignedUrl.sign(src + '?width=' + width, process.env.AUTH_SECRET);
                 srcset.push(url + ' ' + width + 'w');
               }

--- a/source/modules/dynamic_images.js
+++ b/source/modules/dynamic_images.js
@@ -84,7 +84,7 @@ const self = {
               if(!upload || upload.width < 200) return;
 
               // Create dynamic images at 200px intervals up to the original width or the max width set in .env
-              let maxWidth = process.env.IMG_MAX_WIDTH ? process.env.IMG_MAX_WIDTH : upload.width;
+              let maxWidth = process.env.IMG_MAX_WIDTH ? process.env.IMG_MAX_WIDTH + 1: upload.width;
               for(let width = 200; width < maxWidth; width += 200) {
                 let url = SignedUrl.sign(src + '?width=' + width, process.env.AUTH_SECRET);
                 srcset.push(url + ' ' + width + 'w');

--- a/source/modules/dynamic_images.js
+++ b/source/modules/dynamic_images.js
@@ -84,7 +84,7 @@ const self = {
               if(!upload || upload.width < 200) return;
 
               // Create dynamic images at 200px intervals up to the original width or the max width set in .env
-              let maxWidth = process.env.IMG_MAX_WIDTH ? process.env.IMG_MAX_WIDTH + 1: upload.width;
+              let maxWidth = process.env.IMG_MAX_WIDTH ? (Number(process.env.IMG_MAX_WIDTH) + 1): upload.width;
               for(let width = 200; width < maxWidth; width += 200) {
                 let url = SignedUrl.sign(src + '?width=' + width, process.env.AUTH_SECRET);
                 srcset.push(url + ' ' + width + 'w');

--- a/source/modules/helpers/theme_helpers.js
+++ b/source/modules/helpers/theme_helpers.js
@@ -439,7 +439,7 @@ module.exports = (dust) => {
       if(slug) where.slug = { $in: slug.split(',').map(Trim) };
 
       // Sort
-      sortBy = (sortBy || '').match(/^(id|slug|title|createdAt)$/) ? sortBy : 'title';
+      sortBy = 'post.' + ((sortBy || '').match(/^(id|slug|title|createdAt)$/) ? sortBy : 'title');
       sortOrder = (sortOrder || '').match(/^(asc|desc)$/) ? sortOrder.toUpperCase() : 'ASC';
 
       // Fetch authors


### PR DESCRIPTION
Table identifier is necessary in this helper, because 'user' is included. That makes some(?) database rows ambiguous: https://github.com/Postleaf/postleaf/issues/104

I also added an optional .env-value to set the maximum width of dynamically resized images: #102 

---

_All code contributions are subject to the terms of the Contributor License Agreement described in CONTRIBUTING.md._
